### PR TITLE
feat: Add support for Sepolia and Holesky Ethereum testnets

### DIFF
--- a/emerald-api/src/main/java/io/emeraldpay/api/BlockchainType.java
+++ b/emerald-api/src/main/java/io/emeraldpay/api/BlockchainType.java
@@ -15,6 +15,8 @@ public enum BlockchainType {
                 || chain == Chain.TESTNET_GOERLI
                 || chain == Chain.TESTNET_RINKEBY
                 || chain == Chain.TESTNET_ROPSTEN
+                || chain == Chain.TESTNET_HOLESKY
+                || chain == Chain.TESTNET_SEPOLIA
         ) {
             return BlockchainType.ETHEREUM;
         }

--- a/emerald-api/src/main/java/io/emeraldpay/api/Chain.java
+++ b/emerald-api/src/main/java/io/emeraldpay/api/Chain.java
@@ -38,7 +38,9 @@ public enum Chain {
     // TESTNET_FLOONET(10004, "FLOONET", "Floonet Testnet"),
     TESTNET_GOERLI(10005, "GOERLI", "Goerli Testnet"),
     TESTNET_ROPSTEN(10006, "ROPSTEN", "Ropsten Testnet"),
-    TESTNET_RINKEBY(10007, "RINKEBY", "Rinkeby Testnet");
+    TESTNET_RINKEBY(10007, "RINKEBY", "Rinkeby Testnet"),
+    TESTNET_HOLESKY(10008, "HOLESKY", "Holesky Testnet"),
+    TESTNET_SEPOLIA(10009, "SEPOLIA", "Sepolia Testnet");
 
     private final int id;
     private final String code;


### PR DESCRIPTION
- Add new entries for `Chain.TESTNET_HOLESKY` and `Chain.TESTNET_SEPOLIA`.

These are the contemporary public Ethereum testnets.

https://sepolia.dev

https://github.com/eth-clients/holesky

This seems required for being able to use these chains in Dshackle.

---
#### Blocked by
- [x] https://github.com/emeraldpay/emerald-grpc/pull/22